### PR TITLE
feat: add support for 'fail-on-error' flag (IDFGH-10662)

### DIFF
--- a/pyclang/cli_ext.py
+++ b/pyclang/cli_ext.py
@@ -21,6 +21,11 @@ common_args.add_argument(
     type=os.path.realpath,
     help='where the log files will be write to. will use stdout if not specified',
 )
+common_args.add_argument(
+    '--exit-code',
+    action='store_true',
+    help='Exit with code based on the results of the code analysis. By default, exit code reflects the success of running the tool only.',
+)
 
 idf_specific_args = argparse.ArgumentParser(add_help=False)
 idf_specific_args.add_argument(

--- a/pyclang/idf_extension.py
+++ b/pyclang/idf_extension.py
@@ -64,6 +64,12 @@ def action_extensions(base_actions, project_path):
                         'help': 'exclude extra files besides of the project dir. '
                         'This option can be used for multiple times.',
                     },
+                    {
+                        'names': ['--exit-code'],
+                        'help': 'Exit with code based on the results of the code analysis. '
+                        'By default, exit code reflects the success of running the tool only.',
+                        'is_flag': True,
+                    },
                 ],
             },
             'clang-html-report': {

--- a/pyclang/runner.py
+++ b/pyclang/runner.py
@@ -154,6 +154,10 @@ class Runner:
 
         self._call_chain = []
 
+        self.expect_returncode = [0]
+        if not kwargs.get('exit_code', False):
+            self.expect_returncode.append(1)
+
     @property
     def idf_py_cmd(self) -> t.List[str]:
         return _get_call_cmd('idf.py')
@@ -333,7 +337,11 @@ class Runner:
         with open(warn_file, 'w') as fw:
             # clang-tidy would return 1 when found issue, ignore this return code
             run_cmd(
-                cmd, log_stream=log_fs, stream=fw, cwd=folder, expect_returncode=[0, 1]
+                cmd,
+                log_stream=log_fs,
+                stream=fw,
+                cwd=folder,
+                expect_returncode=self.expect_returncode,
             )
 
         log_fs.write(f'clang-tidy report generated: {warn_file}\n')
@@ -445,7 +453,7 @@ class Runner:
             log_stream=log_fs,
             cwd=output_dir,
             ignore_error='AssertionError: No existing files found',
-            expect_returncode=[0, 1],
+            expect_returncode=self.expect_returncode,
         )
         if known_issue:
             log_fs.write('No issue found\n')


### PR DESCRIPTION
This PR is adding new a flag which will raise an exception in case run-clang-tidy.py script will find some error. The default behavior is not changed.

TODO: release a new version

Closes https://github.com/espressif/clang-tidy-runner/issues/34