### PR TITLE
fix: check project files by default

### DIFF
--- a/pyclang/runner.py
+++ b/pyclang/runner.py
@@ -96,7 +96,7 @@ class Runner:
         output_path: t.Optional[str] = None,
         log_path: t.Optional[str] = None,
         # filter arguments
-        all_files: bool = True,
+        all_files: bool = False,
         include_paths: t.Optional[t.List[str]] = None,
         exclude_paths: t.Optional[t.List[str]] = None,
         ignore_clang_checks: t.Optional[t.List[str]] = None,


### PR DESCRIPTION
We have a flag `--all-files` to enable the clang-tidy check for all files.

As the default value of the runner, it should be `False`, to check only the project related files.