### PR TITLE
fix(idf_extension): Don't override the clang_extra_args with empty string if not specified

### DIFF
--- a/pyclang/cli_ext.py
+++ b/pyclang/cli_ext.py
@@ -6,20 +6,20 @@ common_args.add_argument(
     'dirs',
     nargs='+',
     type=os.path.realpath,
-    help='all the dirs you want to run clang-tidy in',
+    help='All the directories you want to run clang-tidy in.',
 )
 common_args.add_argument(
-    '--build-dir', help='build dir. will use "build" if not specified.'
+    '--build-dir', help='Project build directory, will use "build" if not specified.'
 )
 common_args.add_argument(
     '--output-path',
     type=os.path.realpath,
-    help='where the newly generated files locates, will be placed under each "dirs" item if not specified',
+    help='Where the newly generated files locates, will be placed under each "dirs" item if not specified.',
 )
 common_args.add_argument(
     '--log-path',
     type=os.path.realpath,
-    help='where the log files will be write to. will use stdout if not specified',
+    help='Where the log files will be written to, will use stdout if not specified.',
 )
 common_args.add_argument(
     '--exit-code',
@@ -29,29 +29,29 @@ common_args.add_argument(
 
 idf_specific_args = argparse.ArgumentParser(add_help=False)
 idf_specific_args.add_argument(
-    '--limit-file', help='definitions of ignore checks and files/dirs to skip'
+    '--limit-file', help='Definitions of ignore checks and files/directories to skip.'
 )
 idf_specific_args.add_argument(
     '--xtensa-include-dir',
     nargs='?',
     const='/opt/espressif/xtensa-esp32-elf-clang/xtensa-esp32-elf/include/',
-    help='extra include dir for xtensa related header files',
+    help='Extra include directory for Xtensa related header files.',
 )
 
 run_clang_tidy_args = argparse.ArgumentParser(add_help=False)
 run_clang_tidy_args.add_argument(
     '--check-files-regex',
     nargs='*',
-    help='files to be processed (regex on path), will use ".*" to check all files if not specified.',
+    help='Files to be processed (regex on path), will use ".*" to check all files if not specified.',
 )
 run_clang_tidy_args.add_argument(
     '--run-clang-tidy-py',
-    help='run-clang-tidy.py path, this file could be downloaded from llvm. '
+    help='run-clang-tidy.py path, this file could be downloaded from llvm, '
     'will use "run-clang-tidy.py" if not specified.',
 )
 run_clang_tidy_args.add_argument(
     '--clang-extra-args',
-    help='run-clang-tidy.py arguments. will use idf default settings if not specified: '
+    help='run-clang-tidy.py arguments, will use ESP-IDF default settings if not specified: '
     r'-header-filter=".*\..*" '
     '-checks="-*,clang-analyzer-core.NullDereference,clang-analyzer-unix.*,bugprone-*,'
     '-bugprone-macro-parentheses,readability-*,performance-*,-readability-magic-numbers,'
@@ -61,5 +61,5 @@ run_clang_tidy_args.add_argument(
 normalize_args = argparse.ArgumentParser(add_help=False)
 normalize_args.add_argument(
     '--base-dir',
-    help='base dir to translate to relative path. will use IDF_PATH (if set) or current dir if not specified.',
+    help='Base directory to translate to relative path, will use IDF_PATH (if set) or current dir if not specified.',
 )

--- a/pyclang/idf_extension.py
+++ b/pyclang/idf_extension.py
@@ -6,8 +6,7 @@ from pyclang import Runner
 def action_extensions(base_actions, project_path):
     def call_runner(subcommand_name, ctx, args, **kwargs):
         # idf extension don't need default values
-        kwargs['clang_extra_args'] = kwargs.pop('run_clang_tidy_options', '') or ''
-
+        kwargs['clang_extra_args'] = kwargs.pop('run_clang_tidy_options', None)
         kwargs['check_files_regex'] = kwargs.pop('patterns', None)
 
         useful_kwargs = {k: v for k, v in kwargs.items() if v is not None}


### PR DESCRIPTION
When used as an extension in ESP-IDF (with`idf.py clang-check`), the [default clang_extra_args](https://github.com/espressif/clang-tidy-runner/blob/master/pyclang/runner.py#L108-L112) are ignored. This results in some of the configured checks not running. 

This fixes that problem. The extra arguments can be overridden with the `--run-clang-tidy-options`, which allows e.g. specifying more [clang checks](https://clang.llvm.org/extra/clang-tidy/checks/list.html) to run:

`idf.py clang-check --run-clang-tidy-options="-checks=bugprone-undefined-memory-manipulation,readability-avoid-const-params-in-decls"`

---

Also reformatted the `--help` to be more consistent.