### PR TITLE
change(release_process): Use commitizen to generate changelog

### DIFF
--- a/.github/gh_changelog_template.md.j2
+++ b/.github/gh_changelog_template.md.j2
@@ -1,0 +1,20 @@
+{# This changelog template is used for automatically generated GH release notes. #}
+{# It is passed to commitizen's --template option in a GH Actions workflow run. #}
+
+{% for entry in tree %}
+
+{% for change_key, changes in entry.changes.items() %}
+
+{% if change_key %}
+### {{ change_key }}
+{% endif %}
+
+{% for change in changes %}
+{% if change.scope %}
+- **{{ change.scope }}**: {{ change.message }}
+{% elif change.message %}
+- {{ change.message }}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% endfor %}

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -1,0 +1,41 @@
+name: Create GitHub release
+
+on:
+  push:
+    tags:
+      - v*.*
+
+jobs:
+  create_release:
+    name: Create GitHub release
+    if: startsWith(github.ref, 'refs/tags/') && !(contains(github.ref_name, 'dev'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Get version
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        shell: bash
+      - name: Checkout
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install commitizen
+      - name: Generate changelog
+        run: |
+          cz changelog ${{ steps.get_version.outputs.VERSION }} --template .github/gh_changelog_template.md.j2 --file-name changelog_body.md
+          cat changelog_body.md
+      - name: Create release
+        id: create_release
+        uses: softprops/action-gh-release@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          body_path: changelog_body.md
+          name: Version ${{ steps.get_version.outputs.VERSION }}
+          draft: true
+          prerelease: false

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,24 +1,38 @@
-name: Upload Python Package
+# This workflow will upload the pyclang Python package when a release is created
+
+name: PyPI release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [released]
 
 jobs:
-  deploy:
+  build_and_upload:
     runs-on: ubuntu-latest
-    container: python:3.6
     steps:
-      - uses: actions/checkout@v3
-      - name: Install dependencies
-        run: |
-          pip install --upgrade pip
-          pip install wheel twine
-      - name: Build packages
-        run: python setup.py sdist bdist_wheel
-      - name: Publish packages
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: python -m twine upload --verbose dist/* || res=1
+    - uses: actions/checkout@master
+    - name: Set up Python 3.7
+      uses: actions/setup-python@master
+      with:
+        python-version: '3.7'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and upload pyclang ${{ github.event.release.tag_name }}
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        PUBLISHED_VERSION=$(curl https://pypi.org/pypi/pyclang/json 2>/dev/null | jq -r '.info.version')
+        CURRENT_VERSION=$(python setup.py --version 2>/dev/null)
+
+        if [ "$PUBLISHED_VERSION" == "$CURRENT_VERSION" ]; then
+          echo "Version ${PUBLISHED_VERSION} already published, skipping..."
+          exit 1
+        else
+          echo "Packaging and publishing new pyclang version: ${CURRENT_VERSION}"
+          python setup.py sdist bdist_wheel
+          tar -ztvf dist/*
+          twine upload --verbose dist/*
+        fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,9 +25,11 @@ repos:
       - id: black
         exclude: failure_reason.py
         args: [ '--skip-string-normalization' ]
-  - hooks:
-      - id: commitizen
-        stages:
-          - commit-msg
-    repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.37.0
+  - repo: https://github.com/espressif/conventional-precommit-linter
+    rev: v1.4.0
+    hooks:
+      - id: conventional-precommit-linter
+        stages: [commit-msg]
+        args: ['--types=change,ci,docs,feat,fix,refactor,remove,revert,test,perf']
+default_stages: [commit]
+default_install_hook_types: [pre-commit, commit-msg]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,20 @@
 name = "cz_conventional_commits"
 version = "0.4.2"
 tag_format = "v$version"
+update_changelog_on_bump = true
+changelog_merge_prerelease = true
+annotated_tag = true
+bump_message = "change: Update version to $new_version"
+change_type_order = [
+    "BREAKING CHANGE",
+    "New Features",
+    "Bug Fixes",
+    "Code Refactoring",
+    "Performance Improvements"
+]
+
+[tool.commitizen.change_type_map]
+feat = "New Features"
+fix = "Bug Fixes"
+refactor = "Code Refactoring"
+perf = "Performance Improvements"


### PR DESCRIPTION
- Adds automatic release notes generation with commitizens `cz bump`
- Adds automatic GH release creation 
- Adds Espressif's `conventional-precommit-linter` to pre-commit hooks
- Updates the PyPI release pipeline