### PR TITLE
ci(pypi_release): Update distribution build process

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        python -m pip install twine build
     - name: Build and upload pyclang ${{ github.event.release.tag_name }}
       env:
         TWINE_USERNAME: __token__
@@ -32,7 +32,6 @@ jobs:
           exit 1
         else
           echo "Packaging and publishing new pyclang version: ${CURRENT_VERSION}"
-          python setup.py sdist bdist_wheel
-          tar -ztvf dist/*
+          python -m build
           twine upload --verbose dist/*
         fi


### PR DESCRIPTION
Change the distribution building process to use `build` instead of `setuptools`:
   - The `python -m build` method is [recommended](https://twine.readthedocs.io/en/stable/#:~:text=Create%20some%20distributions%20in%20the%20normal%20way%3A)
   - The `tar` step is problematic (see the [recent build failure](https://github.com/espressif/clang-tidy-runner/actions/runs/10667739612/job/29623938035#step:5:116) preventing a PyPI release). This gets rid of that step
   - A wheel is built and uploaded as well instead of just the source
   
Tests:
- Tested in esptool repo (it's the same workflow): https://github.com/radimkarnis/esptool/actions/runs/10700997779
- Resulting release here: https://test.pypi.org/project/esptool-ghtest/4.8.1/#files
