### PR TITLE
Feat/ Espressif clang check and remove unwanted python traceback (IDF-11835)

### DIFF
--- a/pyclang/idf_extension.py
+++ b/pyclang/idf_extension.py
@@ -1,7 +1,17 @@
 import os.path
 import sys
-
+import shutil
 from pyclang import Runner
+
+def check_esp_clang():
+    clang_path = shutil.which("clang-tidy")
+    # xtensa is used only till ESP-IDF v5.0
+    if not clang_path or not any(sub in clang_path for sub in ('esp-clang', 'xtensa-esp32-elf-clang')):
+        raise SystemExit(
+            'ERROR: Espressif Clang was not found on the system.\n\n'
+            'For installation instructions, open the documentation with:\n'
+            'idf.py docs --starting-page=api-guides/tools/idf-clang-tidy.html'
+        )
 
 
 def action_extensions(base_actions, project_path):
@@ -24,6 +34,8 @@ def action_extensions(base_actions, project_path):
                f'set to "{toolchain}".'), file=sys.stderr)
 
     def call_runner(subcommand_name, ctx, args, **kwargs):
+        check_esp_clang()
+
         # idf extension don't need default values
         kwargs['clang_extra_args'] = kwargs.pop('run_clang_tidy_options', None)
         kwargs['check_files_regex'] = kwargs.pop('patterns', None)

--- a/pyclang/utils.py
+++ b/pyclang/utils.py
@@ -55,9 +55,11 @@ def run_cmd(
     returncode = p.wait()
     raw_stderr = to_str(p.stderr.read())
     if returncode not in expect_returncode:
-        sys.stderr.write(raw_stderr)
+        sys.stderr.write(f'\nERROR: Command "{cmd_str}" failed with exit code {returncode}\n')
+        if raw_stderr:
+            sys.stderr.write(f'Details:\n{raw_stderr}\n')
         sys.stderr.flush()
-        raise RuntimeError(f'command "{cmd_str}" failed with exitcode {returncode}')
+        raise SystemExit(returncode)
 
     if raw_stderr:
         if ignore_error and ignore_error in raw_stderr:


### PR DESCRIPTION
1) Verify that Espressif clang is present, to prevent possible usage of system clang.
2) In case of error, raise SystemExit instead of RuntimeError to prevent unwanted Python traceback in output.