### PR TITLE
fix: update pypi release process

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -8,13 +8,13 @@ on:
 
 jobs:
   build_and_upload:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@master
-    - name: Set up Python 3.7
-      uses: actions/setup-python@master
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.7'
+        python-version: '3.13'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Replacing tag `latest` with `24.04` ensures release process will not break again when certain python version is not present in latest ubuntu version.

Publish_pypi job changes:
- Use fixed version of ubuntu - 24.04
- Update python to 3.13
- Set stable version of `actions/setup-python` and `actions/checkout`