### PR TITLE
fix: publish_pypi - Added missing setuptool package

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install twine build
+        python -m pip install twine build setuptools
     - name: Build and upload pyclang ${{ github.event.release.tag_name }}
       env:
         TWINE_USERNAME: __token__


### PR DESCRIPTION
Turned out that [failing publish_pypi process](https://github.com/espressif/clang-tidy-runner/actions/runs/14750565002), is caused by missing `setuptool` package that imported in [setup.py](https://github.com/espressif/clang-tidy-runner/blob/master/setup.py#L5).

`setup.py` is used in the [publish_pypi process to obtain the current version](https://github.com/espressif/clang-tidy-runner/blob/master/.github/workflows/publish_pypi.yml#L28) of clang-tidy-runner.

How I found out?
By debugging in my fork: https://github.com/mfialaf/clang-tidy-runner/actions/runs/14752826680/job/41414019317